### PR TITLE
[Enh] Add Always-Be-Casting Alert

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -29,12 +29,15 @@ namespace GCDTracker
         public bool WheelQueueLockEnabled = true;
         public bool ColorClipEnabled = true;
         public bool ClipAlertEnabled = true;
+        public bool abcAlertEnabled = true;
         public int ClipAlertPrecision = 0;
         public float ClipTextSize = 0.86f;
+        public float abcTextSize = 0.8f;
         public Vector4 clipCol = new(1f, 0f, 0f, 0.667f);
         public Vector4 ClipTextColor = new(0.9f, 0.9f, 0.9f, 1f);
         public Vector4 ClipBackColor = new(1f, 0f, 0f, 1f);
-
+        public Vector4 abcTextColor = new(0f, 0f, 0f, 1f);
+        public Vector4 abcBackColor = new(1f, .7f, 0f, 1f);
         public Vector4 backCol = new(0.376f, 0.376f, 0.376f, 1);
         public Vector4 backColBorder = new(0f, 0f, 0f, 1f);
         public Vector4 frontCol = new(0.9f, 0.9f, 0.9f, 1f);
@@ -50,12 +53,16 @@ namespace GCDTracker
         public bool BarQueueLockEnabled = true;
         public bool BarColorClipEnabled = true;
         public bool BarClipAlertEnabled = true;
+        public bool BarABCAlertEnabled = true;
         public int BarClipAlertPrecision = 0;
         public bool BarRollGCDs = true;
         public float BarClipTextSize = 0.8f;
+        public float BarABCTextSize = 0.8f;
         public Vector4 BarclipCol = new(1f, 0f, 0f, 0.667f);
         public Vector4 BarClipTextColor = new(0.9f, 0.9f, 0.9f, 1f);
         public Vector4 BarClipBackColor = new(1f, 0f, 0f, 1f);
+        public Vector4 BarABCTextColor = new(0f, 0f, 0f, 1f);
+        public Vector4 BarABCBackColor = new(1f, .7f, 0f, 1f);
         public float BarBorderSize = 2f;
         public float BarWidthRatio = 0.9f;
         public float BarHeightRatio = 0.5f;
@@ -244,6 +251,15 @@ namespace GCDTracker
                         }
                         ImGui.Separator();
 
+                        ImGui.Checkbox("Show ABC failure alert", ref abcAlertEnabled);
+                        if (abcAlertEnabled) {
+                            ImGui.ColorEdit4("ABC text color", ref abcTextColor, ImGuiColorEditFlags.NoInputs);
+                            ImGui.SameLine();
+                            ImGui.ColorEdit4("ABC background color", ref abcBackColor, ImGuiColorEditFlags.NoInputs);
+                        }
+                        ImGui.SliderFloat("Clip text size", ref abcTextSize, 0.2f, 2f);
+                        ImGui.Separator();
+
                         ImGui.Checkbox("Color wheel on clipped GCD", ref ColorClipEnabled);
                         ImGui.Checkbox("Show clip alert", ref ClipAlertEnabled);
                         if (ClipAlertEnabled) {
@@ -298,6 +314,15 @@ namespace GCDTracker
                         }
 
                         ImGui.Separator();
+                        ImGui.Checkbox("Show ABC failure alert", ref BarABCAlertEnabled);
+                        if (BarABCAlertEnabled) {
+                            ImGui.ColorEdit4("ABC text color", ref BarABCTextColor, ImGuiColorEditFlags.NoInputs);
+                            ImGui.SameLine();
+                            ImGui.ColorEdit4("ABC background color", ref BarABCBackColor, ImGuiColorEditFlags.NoInputs);
+                        }
+                        ImGui.SliderFloat("Clip text size", ref BarABCTextSize, 0.2f, 2f);
+                        ImGui.Separator();
+
                         ImGui.Checkbox("Color bar on clipped GCD", ref BarColorClipEnabled);
                         ImGui.Checkbox("Show clip alert", ref BarClipAlertEnabled);
                         if (BarClipAlertEnabled) {

--- a/src/PluginUI.cs
+++ b/src/PluginUI.cs
@@ -16,6 +16,8 @@ namespace GCDTracker
         public bool IsVisible { get; set; }
         private readonly Easing clipAnimAlpha;
         private readonly Easing clipAnimPos;
+        private readonly Easing abcAnimAlpha;
+        private readonly Easing abcAnimPos;
         public GCDWheel gcd;
         public ComboTracker ct;
         public Configuration conf;
@@ -36,6 +38,15 @@ namespace GCDTracker
                 Point1 = new(0, 0),
                 Point2 = new(0, -20)
             };
+            abcAnimAlpha = new OutCubic(new(0, 0, 0, 2, 1000)) {
+                Point1 = new(0.25f, 0),
+                Point2 = new(1f, 0)
+            };
+            abcAnimPos = new OutCubic(new(0, 0, 0, 1, 500)) {
+                Point1 = new(0, 0),
+                Point2 = new(0, -20)
+            };
+
             clipText = ["CLIP", "0.0", "0.00"];
         }
 
@@ -190,6 +201,44 @@ namespace GCDTracker
                 textStartPos + animPos,
                 ImGui.GetColorU32(textCol.WithAlpha(1-animAlpha)),
                 clipText[clipTextPrecision]);
+
+            ImGui.SetWindowFontScale(1f);
+            ImGui.PopFont();
+        } 
+
+        public void StartABC() {
+            if (!conf.abcAlertEnabled && !conf.BarABCAlertEnabled) return;
+            abcAnimAlpha.Restart();
+            abcAnimPos.Restart();
+        }
+        public void DrawABC(float relx, float rely, float textSize, Vector4 textCol, Vector4 backCol) {
+            if (!abcAnimAlpha.IsRunning || abcAnimAlpha.IsDone) return;
+
+            ImGui.PushFont(UiBuilder.MonoFont);
+            ImGui.SetWindowFontScale(textSize);
+
+            var textSz = ImGui.CalcTextSize("ABC");
+            var textStartPos =
+                w_cent
+                - (w_size / 2)
+                + new Vector2(w_size.X * relx, w_size.Y * rely)
+                - (textSz / 2);
+            var padding = new Vector2(10, 5) * textSize;
+
+            if (!abcAnimAlpha.IsDone) abcAnimAlpha.Update();
+            if (!abcAnimPos.IsDone) abcAnimPos.Update();
+
+            var animAlpha = abcAnimAlpha.EasedPoint.X;
+            var animPos = abcAnimPos.EasedPoint;
+
+            draw.AddRectFilled(
+                textStartPos - padding + animPos,
+                textStartPos + textSz + padding + animPos,
+                ImGui.GetColorU32(backCol.WithAlpha(1-animAlpha)), 10f);
+            draw.AddText(
+                textStartPos + animPos,
+                ImGui.GetColorU32(textCol.WithAlpha(1-animAlpha)),
+                "ABC");
 
             ImGui.SetWindowFontScale(1f);
             ImGui.PopFont();


### PR DESCRIPTION
Adds an Always-Be-Casting alert that warns the player if they allow the GCD to expire without starting a new cast.  Includes some attempts at checking to make sure the target hasn't died or changed, in which case we expect/don't care that there is a gap in the GCD.  Also reorders the borders for the GCDBar to keep them always on top.