### PR TITLE
[Fix] Clip/ABC Colors Reset Timeout

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -249,8 +249,7 @@ namespace GCDTracker
                             ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
                         ImGui.Checkbox("Show out of combat", ref ShowOutOfCombatGW);
                         ImGui.Checkbox("Show only when GCD running", ref ShowOnlyGCDRunningGW);
-                        if (ShowOnlyGCDRunningGW)
-                            ImGui.SliderFloat("GCD Timeout)", ref GCDTimeout, 0.75f, 5f);
+                        ImGui.SliderFloat("GCD Timeout)", ref GCDTimeout, 0.75f, 5f);
                         ImGui.Checkbox("Show queue lock", ref WheelQueueLockEnabled);
                         if (ImGui.IsItemHovered()){
                             ImGui.BeginTooltip();
@@ -310,8 +309,7 @@ namespace GCDTracker
                             ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
                         ImGui.Checkbox("Show out of combat", ref BarShowOutOfCombat);
                         ImGui.Checkbox("Show only when GCD running", ref BarShowOnlyGCDRunning);
-                        if (BarShowOnlyGCDRunning)
-                            ImGui.SliderFloat("GCD Timeout", ref BarGCDTimeout, 0.75f, 5f);
+                        ImGui.SliderFloat("GCD Timeout", ref BarGCDTimeout, 0.75f, 5f);
                         ImGui.Checkbox("Show queue lock", ref BarQueueLockEnabled);
                         if (ImGui.IsItemHovered()){
                             ImGui.BeginTooltip();

--- a/src/PluginUI.cs
+++ b/src/PluginUI.cs
@@ -64,6 +64,8 @@ namespace GCDTracker
             conf.EnabledGWJobs.TryGetValue(DataStore.ClientState.LocalPlayer.ClassJob.Id, out var enabledJobGW);
             conf.EnabledGBJobs.TryGetValue(DataStore.ClientState.LocalPlayer.ClassJob.Id, out var enabledJobGB);
             conf.EnabledCTJobs.TryGetValue(DataStore.ClientState.LocalPlayer.ClassJob.Id, out var enabledJobCT);
+            
+            
             if (conf.WheelEnabled && !noUI && (conf.WindowMoveableGW || 
                 (enabledJobGW
                     && (conf.ShowOutOfCombatGW || inCombat)


### PR DESCRIPTION
If ShowOnlyGCDRunning is enabled, the code to reset the bar/wheel background colors was never invoked.  This change attempts to fix this by limiting the reset timeout to be slightly less than ShowOnlyGCDRunning's timeout.  Down from a fixed 4s to 50ms before the user-selected GCDTimeout.