### PR TITLE
[Fix] Clip/ABC Color Reset/Timeout

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -249,8 +249,7 @@ namespace GCDTracker
                             ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
                         ImGui.Checkbox("Show out of combat", ref ShowOutOfCombatGW);
                         ImGui.Checkbox("Show only when GCD running", ref ShowOnlyGCDRunningGW);
-                        if (ShowOnlyGCDRunningGW)
-                            ImGui.SliderFloat("GCD Timeout)", ref GCDTimeout, 0.75f, 5f);
+                        ImGui.SliderFloat("GCD Timeout)", ref GCDTimeout, 0.75f, 5f);
                         ImGui.Checkbox("Show queue lock", ref WheelQueueLockEnabled);
                         if (ImGui.IsItemHovered()){
                             ImGui.BeginTooltip();
@@ -310,8 +309,7 @@ namespace GCDTracker
                             ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
                         ImGui.Checkbox("Show out of combat", ref BarShowOutOfCombat);
                         ImGui.Checkbox("Show only when GCD running", ref BarShowOnlyGCDRunning);
-                        if (BarShowOnlyGCDRunning)
-                            ImGui.SliderFloat("GCD Timeout", ref BarGCDTimeout, 0.75f, 5f);
+                        ImGui.SliderFloat("GCD Timeout", ref BarGCDTimeout, 0.75f, 5f);
                         ImGui.Checkbox("Show queue lock", ref BarQueueLockEnabled);
                         if (ImGui.IsItemHovered()){
                             ImGui.BeginTooltip();

--- a/src/PluginUI.cs
+++ b/src/PluginUI.cs
@@ -64,6 +64,7 @@ namespace GCDTracker
             conf.EnabledGWJobs.TryGetValue(DataStore.ClientState.LocalPlayer.ClassJob.Id, out var enabledJobGW);
             conf.EnabledGBJobs.TryGetValue(DataStore.ClientState.LocalPlayer.ClassJob.Id, out var enabledJobGB);
             conf.EnabledCTJobs.TryGetValue(DataStore.ClientState.LocalPlayer.ClassJob.Id, out var enabledJobCT);
+            
             if (conf.WheelEnabled && !noUI && (conf.WindowMoveableGW || 
                 (enabledJobGW
                     && (conf.ShowOutOfCombatGW || inCombat)


### PR DESCRIPTION
If ShowOutOfCombat or ShowOnlyGCDRunning were enabled, DrawGCDWheel and DrawGCDBar were never invoked when the bar wasn't displayed.  As such, the code that reset the bar to the default background color wasn't evaluated.  This fix reduces the time for the reset to fire from a fixed 4s to 50ms less than whatever the current GCDTimeout is set to, ensuring that the bar/wheel is always reset to default just before disappearing.

Has the side effect of changing the default behavior when ShowOutOfCombat(ON) and ShowOnlyGCDRunning(OFF) by lowering the default timeout from 4s to 2s, but this is now adjustable with a GCD Timeout slider in the config for bar/wheel respectively.