### PR TITLE
[Fix] Unify Bar/Wheel Config => Refactor

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -24,12 +24,12 @@ namespace GCDTracker
         public bool WheelEnabled = true;
         [JsonIgnore]
         public bool WindowMoveableGW = false;
-        public bool ShowOutOfCombatGW = false;
-        public bool ShowOnlyGCDRunningGW = false;
-        public bool WheelQueueLockEnabled = true;
+        public bool ShowOutOfCombat = false;
+        public bool ShowOnlyGCDRunning = false;
+        public bool QueueLockEnabled = true;
         public bool ColorClipEnabled = true;
         public bool ColorABCEnabled = true;
-        public bool ClipAlertEnabled = true;
+        public bool clipAlertEnabled = true;
         public bool abcAlertEnabled = true;
         public int ClipAlertPrecision = 0;
         public float GCDTimeout = 2f;
@@ -51,31 +51,11 @@ namespace GCDTracker
         public bool BarEnabled = false;
         [JsonIgnore]
         public bool BarWindowMoveable = false;
-        public bool BarShowOutOfCombat = false;
-        public bool BarShowOnlyGCDRunning = false;
-        public bool BarQueueLockEnabled = true;
-        public bool BarColorClipEnabled = true;
-        public bool BarColorABCEnabled = true;
-        public bool BarClipAlertEnabled = true;
-        public bool BarABCAlertEnabled = true;
-        public int BarClipAlertPrecision = 0;
         public bool BarRollGCDs = true;
-        public float BarClipTextSize = 0.8f;
-        public float BarABCTextSize = 0.8f;
-        public Vector4 BarclipCol = new(1f, 0f, 0f, 0.667f);
-        public Vector4 BarABCCol = new(1f, .7f, 0f, 0.667f);
-        public Vector4 BarClipTextColor = new(0.9f, 0.9f, 0.9f, 1f);
-        public Vector4 BarClipBackColor = new(1f, 0f, 0f, 1f);
-        public Vector4 BarABCTextColor = new(0f, 0f, 0f, 1f);
-        public Vector4 BarABCBackColor = new(1f, .7f, 0f, 1f);
         public float BarBorderSize = 2f;
         public float BarWidthRatio = 0.9f;
         public float BarHeightRatio = 0.5f;
-        public Vector4 BarBackCol = new(0.376f, 0.376f, 0.376f, 0.667f);
         public Vector4 BarBackColBorder = new(0f, 0f, 0f, 1f);
-        public Vector4 BarFrontCol = new(0.9f, 0.9f, 0.9f, 1f);
-        public Vector4 BarOgcdCol = new(1f, 1f, 1f, 1f);
-        public Vector4 BarAnLockCol = new(0.334f, 0.334f, 0.334f, 0.667f);
 
         //Combo
         public bool ComboEnabled = false;
@@ -223,8 +203,6 @@ namespace GCDTracker
                         ClipTextColor = frontCol.WithAlpha(1f);
                         ClipBackColor = clipCol.WithAlpha(1f);
 
-                        BarClipTextColor = BarFrontCol.WithAlpha(1f);
-                        BarClipBackColor = BarclipCol.WithAlpha(1f);
                         break;
                 }
                 Version++;
@@ -240,21 +218,17 @@ namespace GCDTracker
             ImGui.Begin("GCDTracker Settings",ref configEnabled,ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.AlwaysAutoResize);
 
             if (ImGui.BeginTabBar("GCDConfig")){
-                if (ImGui.BeginTabItem("GCDWheel")) {
-                    ImGui.Checkbox("Enable GCDWheel", ref WheelEnabled);
-                    if (WheelEnabled) {
-                        ImGui.Checkbox("Move/resize window", ref WindowMoveableGW);
-                        if (WindowMoveableGW)
-                            ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
-                        ImGui.Checkbox("Show out of combat", ref ShowOutOfCombatGW);
-                        ImGui.Checkbox("Show only when GCD running", ref ShowOnlyGCDRunningGW);
+                if(ImGui.BeginTabItem("GCD Tracker")){
+                        ImGui.Checkbox("Show out of combat", ref ShowOutOfCombat);
+                        ImGui.Checkbox("Show only when GCD running", ref ShowOnlyGCDRunning);
                         ImGui.SliderFloat("GCD Timeout)", ref GCDTimeout, 0.75f, 5f);
-                        ImGui.Checkbox("Show queue lock", ref WheelQueueLockEnabled);
+                        ImGui.Checkbox("Show queue lock", ref QueueLockEnabled);
                         if (ImGui.IsItemHovered()){
                             ImGui.BeginTooltip();
                             ImGui.Text("If enabled, the wheel background will expand on the timing where you can queue the next GCD.");
                             ImGui.EndTooltip();
                         }
+
                         ImGui.Separator();
 
                         ImGui.Checkbox("Color wheel on ABC failure", ref ColorABCEnabled);
@@ -265,11 +239,12 @@ namespace GCDTracker
                             ImGui.ColorEdit4("ABC background color", ref abcBackColor, ImGuiColorEditFlags.NoInputs);
                         }
                         ImGui.SliderFloat("A-B-C text size", ref abcTextSize, 0.2f, 2f);
+
                         ImGui.Separator();
 
                         ImGui.Checkbox("Color wheel on clipped GCD", ref ColorClipEnabled);
-                        ImGui.Checkbox("Show clip alert", ref ClipAlertEnabled);
-                        if (ClipAlertEnabled) {
+                        ImGui.Checkbox("Show clip alert", ref clipAlertEnabled);
+                        if (clipAlertEnabled) {
                             ImGui.SameLine();
                             ImGui.RadioButton("CLIP", ref ClipAlertPrecision, 0);
                             ImGui.SameLine();
@@ -284,6 +259,7 @@ namespace GCDTracker
                         ImGui.SliderFloat("Clip text size", ref ClipTextSize, 0.2f, 2f);
 
                         ImGui.Separator();
+
                         ImGui.Columns(2);
                         ImGui.ColorEdit4("Background bar color", ref backCol, ImGuiColorEditFlags.NoInputs);
                         ImGui.ColorEdit4("Background border color", ref backColBorder, ImGuiColorEditFlags.NoInputs);
@@ -296,82 +272,41 @@ namespace GCDTracker
                         ImGui.Columns(1);
                         ImGui.Separator();
 
-                        DrawJobGrid(ref EnabledGWJobs, true);
+                if (ImGui.BeginTabItem("GCD Display")) {
+                    ImGui.Checkbox("Enable GCDWheel", ref WheelEnabled);
+                    if (WheelEnabled) {
+                        ImGui.Checkbox("Move/resize window", ref WindowMoveableGW);
+                        if (WindowMoveableGW)
+                            ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
                     }
-                    ImGui.EndTabItem();
-                }
-                if (ImGui.BeginTabItem("GCDBar")) {
+
+                        ImGui.Separator();
+
                     ImGui.Checkbox("Enable GCDBar", ref BarEnabled);
                     if (BarEnabled) {
                         ImGui.Checkbox("Move/resize window", ref BarWindowMoveable);
                         if (BarWindowMoveable)
                             ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
-                        ImGui.Checkbox("Show out of combat", ref BarShowOutOfCombat);
-                        ImGui.Checkbox("Show only when GCD running", ref BarShowOnlyGCDRunning);
-                        ImGui.SliderFloat("GCD Timeout", ref GCDTimeout, 0.75f, 5f);
-                        ImGui.Checkbox("Show queue lock", ref BarQueueLockEnabled);
-                        if (ImGui.IsItemHovered()){
-                            ImGui.BeginTooltip();
-                            ImGui.Text("Displays a background bar on the timing where you can queue the next GCD.");
-                            ImGui.EndTooltip();
-                        }
                         ImGui.Checkbox("Roll GCDs", ref BarRollGCDs);
                         if (ImGui.IsItemHovered()){
                             ImGui.BeginTooltip();
                             ImGui.Text("If enabled abilities that start on the next GCD will always be shown inside the bar, even if it overlaps the current GCD.");
                             ImGui.EndTooltip();
                         }
-
-                        ImGui.Separator();
-                        ImGui.Checkbox("Color bar on ABC failure", ref BarColorABCEnabled);
-                        ImGui.Checkbox("Show ABC failure alert", ref abcAlertEnabled);
-                        if (BarABCAlertEnabled) {
-                            ImGui.ColorEdit4("ABC text color", ref BarABCTextColor, ImGuiColorEditFlags.NoInputs);
-                            ImGui.SameLine();
-                            ImGui.ColorEdit4("ABC background color", ref BarABCBackColor, ImGuiColorEditFlags.NoInputs);
-                        }
-                        ImGui.SliderFloat("A-B-C text size", ref BarABCTextSize, 0.2f, 2f);
-                        ImGui.Separator();
-
-                        ImGui.Checkbox("Color bar on clipped GCD", ref BarColorClipEnabled);
-                        ImGui.Checkbox("Show clip alert", ref ClipAlertEnabled);
-                        if (BarClipAlertEnabled) {
-                            ImGui.SameLine();
-                            ImGui.RadioButton("CLIP", ref BarClipAlertPrecision, 0);
-                            ImGui.SameLine();
-                            ImGui.RadioButton("0.X", ref BarClipAlertPrecision, 1);
-                            ImGui.SameLine();
-                            ImGui.RadioButton("0.XX", ref BarClipAlertPrecision, 2);
-
-                            ImGui.ColorEdit4("Clip text color", ref BarClipTextColor, ImGuiColorEditFlags.NoInputs);
-                            ImGui.SameLine();
-                            ImGui.ColorEdit4("Clip background color", ref BarClipBackColor, ImGuiColorEditFlags.NoInputs);
-                        }
-                        ImGui.SliderFloat("Clip text size", ref BarClipTextSize, 0.2f, 2f);
-                        ImGui.Separator();
-                        ImGui.Columns(2);
-                        ImGui.ColorEdit4("Background bar color", ref BarBackCol, ImGuiColorEditFlags.NoInputs);
-                        ImGui.ColorEdit4("Background border color", ref BarBackColBorder, ImGuiColorEditFlags.NoInputs);
-                        ImGui.ColorEdit4("GCD bar color", ref BarFrontCol, ImGuiColorEditFlags.NoInputs);
-                        ImGui.NextColumn();
-                        ImGui.ColorEdit4("GCD start indicator color", ref BarOgcdCol, ImGuiColorEditFlags.NoInputs);
-                        ImGui.ColorEdit4("Animation lock bar color", ref BarAnLockCol, ImGuiColorEditFlags.NoInputs);
-                        ImGui.ColorEdit4("Clipping color", ref BarclipCol, ImGuiColorEditFlags.NoInputs);
-                        ImGui.ColorEdit4("ABC failure color", ref BarABCCol, ImGuiColorEditFlags.NoInputs);
-                        ImGui.Columns(1);
-                        ImGui.Separator();
                         ImGui.SliderFloat("Border size", ref BarBorderSize, 0f, 10f);
                         Vector2 size = new(BarWidthRatio, BarHeightRatio);
                         ImGui.SliderFloat2("Width and height ratio", ref size, 0.1f, 1f);
                         BarWidthRatio = size.X;
                         BarHeightRatio = size.Y;
+                    }
+
                         ImGui.Separator();
 
-                        DrawJobGrid(ref EnabledGBJobs, true);
-                    }
+                        DrawJobGrid(ref EnabledGWJobs, true);
+                }
                     ImGui.EndTabItem();
                 }
-                if (ImGui.BeginTabItem("ComboTrack")) {
+                if (ImGui.BeginTabItem("Combo Tracker")) {
                     ImGui.Checkbox("Enable ComboTrack", ref ComboEnabled);
                     if (ComboEnabled) {
                         ImGui.Checkbox("Move/resize window", ref WindowMoveableCT);

--- a/src/GCDWheel.cs
+++ b/src/GCDWheel.cs
@@ -4,6 +4,7 @@ using Dalamud.Logging;
 using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using GCDTracker.Data;
+using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -166,13 +167,22 @@ namespace GCDTracker {
                 return SecondsSinceGCDEnd >= 0.05f && SecondsSinceGCDEnd < 0.1f;
             return false;
         }
-
-        public void DrawGCDWheel(PluginUI ui, Configuration conf) {
-            float gcdTotal = TotalGCD;
-            float gcdTime = lastElapsedGCD;
-            if (HelperMethods.IsCasting() && DataStore.Action->ElapsedCastTime >= gcdTotal && !HelperMethods.IsTeleport(DataStore.Action->CastId))
-                gcdTime = gcdTotal;
-            if (gcdTotal < 0.1f) return;
+        public Vector4 BackgroundColor(Configuration conf){
+            var bg = conf.backCol;  
+            if (conf.ColorClipEnabled && clippedGCD)  
+                bg = conf.clipCol;  
+            if (conf.ColorABCEnabled && (abcOnLastGCD || abcOnThisGCD))  
+                bg = conf.abcCol;
+            return bg;
+        }
+        private static void DrawAlerts(bool clip, bool abc, float relx, float rely, PluginUI ui, Configuration conf){
+            if (clip)
+                ui.DrawClip(relx, rely, conf.ClipTextSize, conf.ClipTextColor, conf.ClipBackColor, conf.ClipAlertPrecision);
+            if (abc)
+                ui.DrawABC(relx, rely, conf.abcTextSize, conf.abcTextColor, conf.abcBackColor);
+           }
+        
+        private void FlagAlerts(PluginUI ui, Configuration conf){
             if (checkClip && ShouldStartClip()) {
                 ui.StartClip(lastClipDelta);
                 lastClipDelta = 0;
@@ -184,26 +194,25 @@ namespace GCDTracker {
                     abcOnThisGCD = true;
                 }
             }
-            var backgroundCol = conf.backCol;  
-                if (conf.ColorClipEnabled && clippedGCD)  
-                    backgroundCol = conf.clipCol;  
-                if (conf.ColorABCEnabled && (abcOnLastGCD || abcOnThisGCD))  
-                    backgroundCol = conf.abcCol;
+        }
 
+        public void DrawGCDWheel(PluginUI ui, Configuration conf) {
+            float gcdTotal = TotalGCD;
+            float gcdTime = lastElapsedGCD;
+
+            if (HelperMethods.IsCasting() && DataStore.Action->ElapsedCastTime >= gcdTotal && !HelperMethods.IsTeleport(DataStore.Action->CastId))
+                gcdTime = gcdTotal;
+            if (gcdTotal < 0.1f) return;
+            FlagAlerts(ui, conf);
+            DrawAlerts(conf.clipAlertEnabled, conf.abcAlertEnabled, 0.5f, 0, ui, conf);
             // Background
             ui.DrawCircSegment(0f, 1f, 6f * ui.Scale, conf.backColBorder); 
-            ui.DrawCircSegment(0f, 1f, 3f * ui.Scale, backgroundCol);
-            if (conf.WheelQueueLockEnabled) {
+            ui.DrawCircSegment(0f, 1f, 3f * ui.Scale, BackgroundColor(conf));
+            if (conf.QueueLockEnabled) {
                 ui.DrawCircSegment(0.8f, 1, 9f * ui.Scale, conf.backColBorder); 
-                ui.DrawCircSegment(0.8f, 1, 6f * ui.Scale, backgroundCol);
+                ui.DrawCircSegment(0.8f, 1, 6f * ui.Scale, BackgroundColor(conf));
             }
-            if (conf.ClipAlertEnabled)
-                ui.DrawClip(0.5f, 0, conf.ClipTextSize, conf.ClipTextColor, conf.ClipBackColor, conf.ClipAlertPrecision);
-            if (conf.abcAlertEnabled)
-                ui.DrawABC(0.5f, 0, conf.abcTextSize, conf.abcTextColor, conf.abcBackColor);
-
             ui.DrawCircSegment(0f, Math.Min(gcdTime / gcdTotal, 1f), 20f * ui.Scale, conf.frontCol);
-
             foreach (var (ogcd, (anlock, iscast)) in ogcds) {
                 var isClipping = CheckClip(iscast, ogcd, anlock, gcdTotal, gcdTime);
                 ui.DrawCircSegment(ogcd / gcdTotal, (ogcd + anlock) / gcdTotal, 21f * ui.Scale, isClipping ? conf.clipCol : conf.anLockCol);
@@ -214,40 +223,22 @@ namespace GCDTracker {
         public void DrawGCDBar(PluginUI ui, Configuration conf) {
             float gcdTotal = TotalGCD;
             float gcdTime = lastElapsedGCD;
-            if (HelperMethods.IsCasting() && DataStore.Action->ElapsedCastTime >= gcdTotal && !HelperMethods.IsTeleport(DataStore.Action->CastId))
-                gcdTime = gcdTotal;
-            if (gcdTotal < 0.1f) return;
-            if (checkClip && ShouldStartClip()) {
-                ui.StartClip(lastClipDelta);
-                lastClipDelta = 0;
-            }
-            //This is probably computationaly intensive.  Let's only do it if it's actually enabled
-            if (conf.BarABCAlertEnabled){
-                if (!clippedGCD && ShowABCAlert()) {
-                    ui.StartABC();
-                    abcOnThisGCD = true;
-                }
-            }
-            var backgroundCol = conf.BarBackCol;
-            if (conf.BarColorClipEnabled && clippedGCD)
-                backgroundCol = conf.BarclipCol;
-            if (conf.BarColorABCEnabled && (abcOnLastGCD || abcOnThisGCD))
-                backgroundCol = conf.BarABCCol;
             float barHeight = ui.w_size.Y * conf.BarHeightRatio;
             float barWidth = ui.w_size.X * conf.BarWidthRatio;
             float borderSize = conf.BarBorderSize;
-
+            float barGCDClipTime = 0;
             Vector2 start = new(ui.w_cent.X - barWidth / 2, ui.w_cent.Y - barHeight / 2);
             Vector2 end = new(ui.w_cent.X + barWidth / 2, ui.w_cent.Y + barHeight / 2);
-            // Background
-            ui.DrawBar(0f, 1f, barWidth, barHeight, backgroundCol);
-            if (conf.BarClipAlertEnabled)
-                ui.DrawClip((conf.BarWidthRatio + 1) / 2.1f, -0.3f, conf.BarClipTextSize, conf.BarClipTextColor, conf.BarClipBackColor, conf.BarClipAlertPrecision);
-            if (conf.BarABCAlertEnabled)
-                ui.DrawABC((conf.BarWidthRatio + 1) / 2.1f, -0.3f, conf.BarABCTextSize, conf.BarABCTextColor, conf.BarABCBackColor);
-            ui.DrawBar(0f, Math.Min(gcdTime / gcdTotal, 1f), barWidth, barHeight, conf.BarFrontCol);
 
-            float barGCDClipTime = 0;
+            if (HelperMethods.IsCasting() && DataStore.Action->ElapsedCastTime >= gcdTotal && !HelperMethods.IsTeleport(DataStore.Action->CastId))
+                gcdTime = gcdTotal;
+            if (gcdTotal < 0.1f) return;
+            FlagAlerts(ui, conf);
+            DrawAlerts(conf.clipAlertEnabled, conf.abcAlertEnabled, (conf.BarWidthRatio + 1) / 2.1f, -0.3f, ui, conf);
+            // Background
+            ui.DrawBar(0f, 1f, barWidth, barHeight, BackgroundColor(conf));
+            ui.DrawBar(0f, Math.Min(gcdTime / gcdTotal, 1f), barWidth, barHeight, conf.frontCol);
+
             foreach (var (ogcd, (anlock, iscast)) in ogcds) {
                 var isClipping = CheckClip(iscast, ogcd, anlock, gcdTotal, gcdTime);
                 float ogcdStart = (conf.BarRollGCDs && gcdTotal - ogcd < 0.2f) ? 0 + barGCDClipTime : ogcd;
@@ -258,10 +249,9 @@ namespace GCDTracker {
                     barGCDClipTime += ogcdStart + anlock - gcdTotal;
                     
                     // Draw the clipped part at the beggining
-                    ui.DrawBar(0, barGCDClipTime/gcdTotal, barWidth, barHeight, conf.BarclipCol);
+                    ui.DrawBar(0, barGCDClipTime/gcdTotal, barWidth, barHeight, conf.clipCol);
                 }
-                
-                ui.DrawBar(ogcdStart / gcdTotal, ogcdEnd / gcdTotal, barWidth, barHeight, isClipping ? conf.BarclipCol : conf.BarAnLockCol);
+                ui.DrawBar(ogcdStart / gcdTotal, ogcdEnd / gcdTotal, barWidth, barHeight, isClipping ? conf.clipCol : conf.anLockCol);
                 if (!iscast && (!isClipping || ogcdStart > 0.01f)) {
                     Vector2 clipPos = new(
                         ui.w_cent.X + (ogcdStart / gcdTotal * barWidth) - (barWidth / 2),
@@ -269,17 +259,11 @@ namespace GCDTracker {
                     );
                     ui.DrawRectFilled(clipPos,
                         clipPos + new Vector2(2f*ui.Scale, barHeight-2f),
-                        conf.BarOgcdCol);
+                        conf.ogcdCol);
                 }
             }
             //borders last so they're on top of all elements
-            if (borderSize > 0) {
-                ui.DrawRect(
-                    start - new Vector2(borderSize, borderSize)/2,
-                    end + new Vector2(borderSize, borderSize)/2,
-                    conf.BarBackColBorder, borderSize);
-            }
-            if (conf.BarQueueLockEnabled) {
+            if (conf.QueueLockEnabled) {
                 Vector2 queueLock = new(
                     ui.w_cent.X + (0.8f * barWidth) - (barWidth / 2),
                     ui.w_cent.Y - (barHeight / 2) - (borderSize / 2)
@@ -287,6 +271,12 @@ namespace GCDTracker {
                 ui.DrawRectFilled(queueLock,
                     queueLock + new Vector2(borderSize, barHeight + (borderSize / 2)),
                     conf.BarBackColBorder);
+            }
+            if (borderSize > 0) {
+                ui.DrawRect(
+                    start - new Vector2(borderSize, borderSize)/2,
+                    end + new Vector2(borderSize, borderSize)/2,
+                    conf.BarBackColBorder, borderSize);
             }
         }
 

--- a/src/PluginUI.cs
+++ b/src/PluginUI.cs
@@ -67,8 +67,8 @@ namespace GCDTracker
             
             if (conf.WheelEnabled && !noUI && (conf.WindowMoveableGW || 
                 (enabledJobGW
-                    && (conf.ShowOutOfCombatGW || inCombat)
-                    && (!conf.ShowOnlyGCDRunningGW || gcd.SecondsSinceGCDEnd < conf.GCDTimeout)
+                    && (conf.ShowOutOfCombat || inCombat)
+                    && (!conf.ShowOnlyGCDRunning || gcd.SecondsSinceGCDEnd < conf.GCDTimeout)
                     ))) {
                 SetupWindow("GCDTracker_GCDWheel", conf.WindowMoveableGW);
                 gcd.DrawGCDWheel(this, conf);
@@ -77,8 +77,8 @@ namespace GCDTracker
 
             if (conf.BarEnabled && !noUI && (conf.BarWindowMoveable || 
                 (enabledJobGB 
-                    && (conf.BarShowOutOfCombat || inCombat)
-                    && (!conf.BarShowOnlyGCDRunning || gcd.SecondsSinceGCDEnd < conf.GCDTimeout)
+                    && (conf.ShowOutOfCombat || inCombat)
+                    && (!conf.ShowOnlyGCDRunning || gcd.SecondsSinceGCDEnd < conf.GCDTimeout)
                     ))) {
                 SetupWindow("GCDTracker_Bar", conf.BarWindowMoveable);
                 gcd.DrawGCDBar(this, conf);
@@ -163,7 +163,7 @@ namespace GCDTracker
         }
 
         public void StartClip(float ms) {
-            if (!conf.ClipAlertEnabled && !conf.BarClipAlertEnabled) return;
+            if (!conf.clipAlertEnabled && !conf.clipAlertEnabled) return;
             clipText[1] = string.Format("{0:0.0}", ms);
             clipText[2] = string.Format("{0:0.00}", ms);
             clipAnimAlpha.Restart();
@@ -208,7 +208,7 @@ namespace GCDTracker
         } 
 
         public void StartABC() {
-            if (!conf.abcAlertEnabled && !conf.BarABCAlertEnabled) return;
+            if (!conf.abcAlertEnabled && !conf.abcAlertEnabled) return;
             abcAnimAlpha.Restart();
             abcAnimPos.Restart();
         }


### PR DESCRIPTION
There is almost certainly no reasonable use-case for separate settings for GCDBar and GCDWheel.  Users will likely use one, or the other, and if they're using both, having the same settings shared is probably more convenient anyway.  This unifies the Bar/Wheel Configs into "GCD Tracker" and "GCD Display" tabs, giving control over the same options, but only duplicated between bar and wheel if necessary.

This change enabled some minor refactoring of GCDWheel.cs -- since now both display modes share configs, it is possible to create helper methods to avoid code duplication.