### PR TITLE
[Feat] Add Option to Hide while Teleporting

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -26,6 +26,7 @@ namespace GCDTracker
         public bool WindowMoveableGW = false;
         public bool ShowOutOfCombat = false;
         public bool HideAlertsOutOfCombat = false;
+        public bool HideIfTP = false;
         public bool ShowOnlyGCDRunning = false;
         public bool QueueLockEnabled = true;
         public bool ColorClipEnabled = true;
@@ -224,6 +225,12 @@ namespace GCDTracker
                     ImGui.Checkbox("Show out of combat", ref ShowOutOfCombat);
                     ImGui.Checkbox("Hide alerts out of combat", ref HideAlertsOutOfCombat);
                     ImGui.Checkbox("Show only when GCD running", ref ShowOnlyGCDRunning);
+                    ImGui.Checkbox("Hide while teleporting", ref HideIfTP);
+                        if (ImGui.IsItemHovered()){
+                        ImGui.BeginTooltip();
+                        ImGui.Text("Hides the GCDTracker while teleporting, if show only when GCD running is also selected.");
+                        ImGui.EndTooltip();
+                    }
                     ImGui.SliderInt("GCD Timeout Multiplier", ref GCDTimeout, 1, 20);
                     if (ImGui.IsItemHovered()){
                         ImGui.BeginTooltip();

--- a/src/PluginUI.cs
+++ b/src/PluginUI.cs
@@ -67,7 +67,7 @@ namespace GCDTracker
             if (conf.WheelEnabled && !noUI && (conf.WindowMoveableGW || 
                 (enabledJobGW
                     && (conf.ShowOutOfCombat || inCombat)
-                    && (!conf.ShowOnlyGCDRunning || gcd.idleTimer < 20 * conf.GCDTimeout)
+                    && (!conf.ShowOnlyGCDRunning || (gcd.idleTimer < 20 * conf.GCDTimeout && !gcd.lastActionTP))
                     ))) {
                 SetupWindow("GCDTracker_GCDWheel", conf.WindowMoveableGW);
                 gcd.DrawGCDWheel(this, conf);
@@ -77,7 +77,7 @@ namespace GCDTracker
             if (conf.BarEnabled && !noUI && (conf.BarWindowMoveable || 
                 (enabledJobGB 
                     && (conf.ShowOutOfCombat || inCombat)
-                    && (!conf.ShowOnlyGCDRunning || gcd.idleTimer < 20 * conf.GCDTimeout)
+                    && (!conf.ShowOnlyGCDRunning || (gcd.idleTimer < 20 * conf.GCDTimeout && !gcd.lastActionTP))
                     ))) {
                 SetupWindow("GCDTracker_Bar", conf.BarWindowMoveable);
                 gcd.DrawGCDBar(this, conf);


### PR DESCRIPTION
This commit adds a checkbox in the settings that hides the GCDTracker during a teleport while ShowOnlyGCDRunning is also true.  Has no effect otherwise.